### PR TITLE
Newed Cuda base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 
 # Set the base image to Ubuntu 18.04 and NVIDIA GPU from https://hub.docker.com/r/nvidia/cuda
 # or from https://ngc.nvidia.com/catalog/containers/nvidia:cuda/tags
-FROM nvidia/cuda:11.6.0-base-ubuntu18.04
+FROM nvidia/cuda:11.6.2-base-ubuntu18.04
 
 # Author and maintainer
 MAINTAINER Yang Liu <yang.liu@jax.org>


### PR DESCRIPTION
```
stain@xena:~/src/nanome$ docker build .
Sending build context to Docker daemon  370.8MB
Step 1/20 : FROM nvidia/cuda:11.6.0-base-ubuntu18.04
 ---> 059c94155a4e
Step 2/20 : MAINTAINER Yang Liu <yang.liu@jax.org>
 ---> Using cache
 ---> 4d8822e22a36
Step 3/20 : LABEL description="Nanome project in Li Lab at The Jackson Laboratory"       author="yang.liu@jax.org"
 ---> Using cache
 ---> b0a3feb2b49f
Step 4/20 : ARG GUPPY_VERSION=6.0.1
 ---> Using cache
 ---> 0a93c7441dce
Step 5/20 : ARG REMORA_VERSION=0.1.2
 ---> Using cache
 ---> c4a5e16670d6
Step 6/20 : ARG MEGALODON_VERSION=2.4.2
 ---> Using cache
 ---> c3874bf55ba9
Step 7/20 : ARG BUILD_PACKAGES="wget apt-transport-https procps git curl libnvidia-compute-460-server"
 ---> Using cache
 ---> deb1ea83d899
Step 8/20 : ARG DEBIAN_FRONTEND="noninteractive"
 ---> Using cache
 ---> f6796dc6ac0a
Step 9/20 : RUN apt-get -q update &&     DEBIAN_FRONTEND="noninteractive" apt-get -q install --yes ${BUILD_PACKAGES} &&     cd /tmp &&     wget -q https://mirror.oxfordnanoportal.com/software/analysis/ont_guppy_${GUPPY_VERSION}-1~bionic_amd64.deb &&     DEBIAN_FRONTEND="noninteractive" apt-get -q install --yes /tmp/ont_guppy_${GUPPY_VERSION}-1~bionic_amd64.deb &&     rm *.deb &&     apt-get autoremove --purge --yes &&     apt-get clean &&     rm -rf /var/lib/apt/lists/*
 ---> Running in 77b39d65f882
Get:1 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease [1575 B]
Err:1 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY A4B469963BF863CC
Get:2 http://security.ubuntu.com/ubuntu bionic-security InRelease [88.7 kB]
...
Get:19 http://archive.ubuntu.com/ubuntu bionic-backports/universe amd64 Packages [12.9 kB]
Reading package lists...
W: GPG error: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY A4B469963BF863CC
E: The repository 'https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease' is not signed.
The command '/bin/sh -c apt-get -q update &&     DEBIAN_FRONTEND="noninteractive" apt-get -q install --yes ${BUILD_PACKAGES} &&     cd /tmp &&     wget -q https://mirror.oxfordnanoportal.com/software/analysis/ont_guppy_${GUPPY_VERSION}-1~bionic_amd64.deb &&     DEBIAN_FRONTEND="noninteractive" apt-get -q install --yes /tmp/ont_guppy_${GUPPY_VERSION}-1~bionic_amd64.deb &&     rm *.deb &&     apt-get autoremove --purge --yes &&     apt-get clean &&     rm -rf /var/lib/apt/lists/*' returned a non-zero code: 100
```

This seems to be a bug in the base image `nvidia/cuda:11.6.0-base-ubuntu18.04` which is no longer maintained - using `11.6.2-base-ubuntu18.04` seems to fix it.

It also seems the GitHub Actions are happily testing the workflow with an older version of the Docker image (which would then not match `src`) - would suggest adding a local docker build to the GH pipeline.